### PR TITLE
Fix: works on emacs27+

### DIFF
--- a/theme-changer.el
+++ b/theme-changer.el
@@ -76,6 +76,10 @@
 (defvar theme-changer-mode "deftheme"
   "Specify the theme change mode: \"color-theme\" or Emacs 24's \"deftheme\".")
 
+(defcustom theme-changer-delay-seconds 0
+  "Specify the delay seconds when switch themes at sunrise and sunset."
+  :type 'integer)
+
 (defun theme-changer-hour-fraction-to-time (date hour-fraction)
   (let*
       ((now (decode-time (current-time)))
@@ -99,8 +103,13 @@
 (defun theme-changer-sunrise-sunset-times (date)
   (let*
       ((l (solar-sunrise-sunset date))
-       (sunrise-time (theme-changer-hour-fraction-to-time date (caar l)))
-       (sunset-time (theme-changer-hour-fraction-to-time date (caadr l))))
+       (sunrise-time (time-add (theme-changer-hour-fraction-to-time date (caar l))
+                               (seconds-to-time theme-changer-delay-seconds)))
+       (sunset-time (time-add (theme-changer-hour-fraction-to-time date (caadr l))
+                              (seconds-to-time theme-changer-delay-seconds))))
+    (when (> emacs-major-version 26)
+      (setq sunrise-time (encode-time (decode-time sunrise-time)))
+      (setq sunset-time (encode-time (decode-time sunset-time))))
     (list sunrise-time sunset-time)))
 
 (defun theme-changer-today () (calendar-current-date))

--- a/theme-changer.el
+++ b/theme-changer.el
@@ -111,7 +111,7 @@
 
 (defun theme-changer-add-second (time)
   (let ((newtime (time-add time (seconds-to-time 1))))
-    (if EMACS27+
+    (if (> emacs-major-version 26)
         (encode-time (decode-time newtime))
       newtime)))
 

--- a/theme-changer.el
+++ b/theme-changer.el
@@ -110,7 +110,10 @@
    (+ 1 (calendar-absolute-from-gregorian (theme-changer-today)))))
 
 (defun theme-changer-add-second (time)
-  (time-add time (seconds-to-time 1)))
+  (let ((newtime (time-add time (seconds-to-time 1))))
+    (if EMACS27+
+        (encode-time (decode-time newtime))
+      newtime)))
 
 (defun theme-changer-switch-theme (old new)
   "Change the theme from OLD to NEW.


### PR DESCRIPTION
Hi,

The current version does not automatically switch the theme at sunrise and
sunset times because the "time-add" function of emacs27 has changed, and I have
fixed this issue to add additional processing for emacs27.

----

#