### PR TITLE
Add support for running functions before and after change

### DIFF
--- a/theme-changer.el
+++ b/theme-changer.el
@@ -76,6 +76,12 @@
 (defvar theme-changer-mode "deftheme"
   "Specify the theme change mode: \"color-theme\" or Emacs 24's \"deftheme\".")
 
+(defvar theme-changer-pre-change-functions (list)
+  "Functions to run before changing themes.  Takes one argument of theme name being disabled.")
+
+(defvar theme-changer-post-change-functions (list)
+  "Functions to run after changing themes.  Takes one argument of theme name being enabled.")
+
 (defun theme-changer-hour-fraction-to-time (date hour-fraction)
   (let*
       ((now (decode-time (current-time)))
@@ -130,8 +136,10 @@ Returns the theme that was enabled."
         (enable (if (not (string= theme-changer-mode "deftheme"))
                     (lambda () (apply (symbol-function new) '()))
                   (lambda () (load-theme new t)))))
+    (run-hook-with-args theme-changer-pre-change-functions old)
     (disable-theme old)
     (if new (funcall enable))
+    (run-hook-with-args theme-changer-post-change-functions new)
     new))
 
 (defun change-theme (day-theme night-theme &optional old-theme)


### PR DESCRIPTION
Some packages calculate faces by the current theme.  Switching themes can cause these faces to be incorrect.  Providing a method by which they may be activated/deactivated or other things may be enabled/disabled based on the present theme is particularly helpful.