### PR TITLE
Fix for wrongly use `run-hook-with-args`

### DIFF
--- a/theme-changer.el
+++ b/theme-changer.el
@@ -148,10 +148,10 @@ Returns the theme that was enabled."
         (enable (if (not (string= theme-changer-mode "deftheme"))
                     (lambda () (apply (symbol-function new) '()))
                   (lambda () (load-theme new t)))))
-    (run-hook-with-args theme-changer-pre-change-functions old)
+    (run-hook-with-args 'theme-changer-pre-change-functions old)
     (disable-theme old)
     (if new (funcall enable))
-    (run-hook-with-args theme-changer-post-change-functions new)
+    (run-hook-with-args 'theme-changer-post-change-functions new)
     new))
 
 (defun change-theme (day-theme night-theme &optional old-theme)


### PR DESCRIPTION
`run-hook-with-args` function require a symbol instead of a value.
I think you need to insert the single quote before theme-changer-post-change-functions.

Please see, https://github.com/hadronzoo/theme-changer/pull/16