### PR TITLE
Fix hooks

### DIFF
--- a/theme-changer.el
+++ b/theme-changer.el
@@ -148,10 +148,10 @@ Returns the theme that was enabled."
         (enable (if (not (string= theme-changer-mode "deftheme"))
                     (lambda () (apply (symbol-function new) '()))
                   (lambda () (load-theme new t)))))
-    (run-hook-with-args theme-changer-pre-change-functions old)
+    (run-hook-with-args 'theme-changer-pre-change-functions old)
     (disable-theme old)
     (if new (funcall enable))
-    (run-hook-with-args theme-changer-post-change-functions new)
+    (run-hook-with-args 'theme-changer-post-change-functions new)
     new))
 
 (defun change-theme (day-theme night-theme &optional old-theme)


### PR DESCRIPTION
According to `run-hook-with-args` a hook must be a symbol, a hook variable:
> Run HOOK with the specified arguments ARGS.
> HOOK should be a symbol, a hook variable.