### PR TITLE
fix "Args out of range: 0", because of call elt for empty list

### DIFF
--- a/theme-changer.el
+++ b/theme-changer.el
@@ -186,7 +186,9 @@ If NEW is set to nil, shall switch to default Emacs theme.
 
 Returns the theme that was enabled."
   (let ((new (if (listp new)
-                 (elt new (random (length new)))
+		 (if (zerop (length new))
+		     nil
+                 (elt new (random (length new))))
                new))
         (enable (if (not (string= theme-changer-mode "deftheme"))
                     (lambda () (apply (symbol-function new) '()))


### PR DESCRIPTION
In my config I has
```
(change-theme nil 'tango-dark)
```
all worked fine, but with emacs 29.1 I got `theme-changer/:config: Args out of range: 0`

This is fix for this problem.